### PR TITLE
Fixes for QueryParser when using numeric values in search on Postgresql

### DIFF
--- a/src/QueryParser.php
+++ b/src/QueryParser.php
@@ -211,7 +211,7 @@ class QueryParser extends \Phalcon\Di\Injectable
             $values = array_values($tmpMapped);
 
             foreach ($keys as $key => $field) {
-                $conditions .= " AND {$field} LIKE ?{$key}";
+                $conditions .= " AND CAST({$field} AS TEXT) LIKE ?{$key}";
             }
 
             if (isset($betweenMap)) {

--- a/src/QueryParser.php
+++ b/src/QueryParser.php
@@ -110,7 +110,7 @@ class QueryParser extends \Phalcon\Di\Injectable
      * @param  string $unparsed Unparsed search string
      * @return array            An array of fieldname=>value search parameters
      */
-    protected function parseSearchParameters(string $unparsed): array
+    public function parseSearchParameters(string $unparsed): array
     {
         // Strip parens that come with the request string
         $unparsed = trim($unparsed, '()');


### PR DESCRIPTION
Postgresql will throw an error when trying to use LIKE operator with a numeric field (int), so you need to cast as text in order to make it work and this pull request fixes this issue.