### PR TITLE
support different (!=) in query

### DIFF
--- a/src/QueryParserCustomFields.php
+++ b/src/QueryParserCustomFields.php
@@ -77,6 +77,7 @@ class QueryParserCustomFields extends QueryParser
         ':' => '=',
         '>' => '>=',
         '<' => '<=',
+        '~' => '!=',
     ];
 
     /**
@@ -620,7 +621,7 @@ class QueryParserCustomFields extends QueryParser
             $fieldChain = explode(';', $fieldChain);
 
             foreach ($fieldChain as $field) {
-                $splitField = preg_split('#(:|>|<)#', $field, -1, PREG_SPLIT_DELIM_CAPTURE);
+                $splitField = preg_split('#(:|>|<|~)#', $field, -1, PREG_SPLIT_DELIM_CAPTURE);
 
                 if (count($splitField) > 3) {
                     $splitField[2] = implode('', array_splice($splitField, 2));


### PR DESCRIPTION
- We need to allow calls and filter fields  by `different(!=) than  x`. 
   0.5 version allow us that but 0.1 version dont.

example query `/resource?q=(field~value1,field2:value2)&sort=field|ASC`
