### PR TITLE
set previous relationSearchFields value if we dont have rparams

### DIFF
--- a/src/Converter/RequestUriToSql.php
+++ b/src/Converter/RequestUriToSql.php
@@ -529,7 +529,7 @@ class RequestUriToSql extends Injectable implements ConverterInterface
      */
     protected function prepareParams(array $unparsed): void
     {
-        $this->relationSearchFields = array_key_exists('rparams', $unparsed) ? $this->parseRelationParameters($unparsed['rparams']) : [];
+        $this->relationSearchFields = array_key_exists('rparams', $unparsed) ? $this->parseRelationParameters($unparsed['rparams']) : $this->relationSearchFields;
         $this->customSearchFields = array_key_exists('cparams', $unparsed) ? $this->parseSearchParameters($unparsed['cparams'])['mapped'] : [];
         $this->normalSearchFields = array_key_exists('params', $unparsed) ? $this->parseSearchParameters($unparsed['params'])['mapped'] : [];
     }


### PR DESCRIPTION
since It is posible at this point that `relationSearchFields` comes with values from the sort function, we should set this previous value instead of an empty array.